### PR TITLE
Fixed typo for jail.local in secure.sh

### DIFF
--- a/secure.sh
+++ b/secure.sh
@@ -27,7 +27,7 @@ multi on
 EOF
 
 # --- Enable fail2ban
-sudo cp fail2ban.local /etc/fail2ban/
+sudo cp jail.local /etc/fail2ban/
 sudo systemctl enable fail2ban
 sudo systemctl start fail2ban
 


### PR DESCRIPTION
jail.local was misspelled with fail2ban.local when copying jail.local to /etc/fail2ban/ in the script secure.sh.