### PR TITLE
Do not disable module loading

### DIFF
--- a/secure.sh
+++ b/secure.sh
@@ -13,7 +13,7 @@ sudo ufw default allow outgoing
 sudo ufw enable
 
 # --- Harden /etc/sysctl.conf
-sudo sysctl kernel.modules_disabled=1
+#sudo sysctl kernel.modules_disabled=1 # DANGEROUS
 sudo sysctl -a
 sudo sysctl -A
 sudo sysctl mib


### PR DESCRIPTION
Comments out a sysctl command that disables kernel modules (un)loading. Which makes kernels (for example `linux-generic`) unable to use devices like GPUs, network cards and virtual stuff.

Closes #3